### PR TITLE
Old Hispanic Search

### DIFF
--- a/src/SearchPanel.svelte
+++ b/src/SearchPanel.svelte
@@ -36,6 +36,7 @@
 
     let /** @type {Checkbox} */ aquitanianCheckbox = $state(),
         /** @type {Checkbox} */ squareCheckbox = $state(),
+        /** @type {Checkbox} */ ohCheckbox = $state(),
         /** @type {Checkbox} */ liquescentCheckbox = $state(),
         /** @type {Checkbox} */ quilismaCheckbox = $state(),
         /** @type {Checkbox} */ oriscusCheckbox = $state();
@@ -90,6 +91,7 @@
         resultListOfChants = filterByMusicScript(resultListOfChants, {
             aquitanian: aquitanianCheckbox.isChecked(),
             square: squareCheckbox.isChecked(),
+            old_hispanic: ohCheckbox.isChecked(),
         });
 
         /* Second layer of filtering: Ornamental shapes */
@@ -198,7 +200,7 @@
     }
 
     export function loadDefaultOptions() {
-        [aquitanianCheckbox, squareCheckbox].forEach((e) => e.setChecked());
+        [aquitanianCheckbox, squareCheckbox, ohCheckbox].forEach((e) => e.setChecked());
         [liquescentCheckbox, quilismaCheckbox, oriscusCheckbox].forEach((e) =>
             e.setUnchecked(),
         );
@@ -234,6 +236,8 @@
                 >Aquitanian</Checkbox
             >
             <Checkbox value="square" bind:this={squareCheckbox}>Square</Checkbox
+            >
+            <Checkbox value="old_hispanic" bind:this={ohCheckbox}>Old Hispanic</Checkbox
             >
             <hr />
 

--- a/src/search/search.mjs
+++ b/src/search/search.mjs
@@ -13,6 +13,9 @@ export function filterByMusicScript(chantList, musicScripts) {
         } else if (musicScripts.square && chant.notationType == "square") {
             return true;
         }
+        else if (musicScripts.old_hispanic && chant.notationType == "old_hispanic") {
+            return true;
+        }
         return false;
     });
 

--- a/src/utility/components.js
+++ b/src/utility/components.js
@@ -54,6 +54,28 @@ export class NeumeComponentAQ extends NeumeComponent {
   }
 }
 
+/**
+ * The Neume Component class for Old Hispanic notation.
+ */
+export class NeumeComponentOH extends NeumeComponent {
+  /**
+   * Constructor of a Neume Component for Aquitanian notation.
+   * @param {String} id (required) the `@xml:id` attribute of the neume component 
+   * @param {*} tilt (optional) the tilt direction of the neume component (e.g., "s", "ne")
+   * @param {*} ornamental (optional) the ornamental shape of the component
+   * @param {String} intm (optional) interval of the current neume component relative to the previous ("n", "u", "d", "s")
+   */
+  constructor(id, tilt, curve, ornamental, intm) {
+    super(id, tilt, curve, ornamental);
+    if (intm != null){
+      this.intm = String(intm);
+    }
+    else{
+      this.intm = null;
+    }
+  }
+}
+
 
 export class SyllableWord {
   /**


### PR DESCRIPTION
Resolves (#104) and (#95)

Currently uses this repo which contains 1 Aquitanian, 1 Square, and 1 Old Hispanic MEI: https://github.com/DeannaLC/MEI-Samples

Completed:
- Added NeumeComponentOH with an optional intm variable
- Sets an MEI's notationType to old_hispanic if `@lines = 0` or `@lines = undefined`
- Adds various checks for null values (Old Hispanic MEI in use sometimes has variables in different places or is missing variables)
- Added Old Hispanic checkbox

To Do:
- Fix table row (text is missing)
- Fix more details (doesn't do anything when clicked)
- Functionality for contour search in Old Hispanic